### PR TITLE
Fix missing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-explorer-taco",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "a simple CLI json explorer utility",
   "main": "lib/index.js",
   "scripts": {
@@ -22,7 +22,8 @@
     "iced-error": "0.0.9",
     "iced-runtime-3": "^3.0.4",
     "iced-utils": "^0.1.24",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "purepack": "^1.0.4"
   },
   "devDependencies": {
     "iced-coffee-script-3": "^110.0.0"


### PR DESCRIPTION
Fixes
```
» echo "{}" | json -p
module.js:471
    throw err;
    ^

Error: Cannot find module 'purepack'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/usr/lib/node_modules/json-explorer-taco/lib/main.js:17:12)
    at Object.<anonymous> (/usr/lib/node_modules/json-explorer-taco/lib/main.js:302:4)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
```